### PR TITLE
Skip execution if no git repository found instead of throwing an error

### DIFF
--- a/src/main/java/io/github/pepperkit/githooks/GitHooksManager.java
+++ b/src/main/java/io/github/pepperkit/githooks/GitHooksManager.java
@@ -91,16 +91,19 @@ public class GitHooksManager {
     }
 
     /**
+     * Determines if current working directory is the root directory of a git repository.
+     * @return true if it is a git repository, else false
+     */
+    public boolean isGitRepository() {
+      return Files.exists(GIT_PATH);
+    }
+
+    /**
      * Checks that git hooks directory exists, and creates it if it doesn't.
      * @throws IllegalStateException if git repository was not initialized
      *                               or there's an error on creating git hooks directory
      */
     void checkGitHooksDirAndCreateIfMissing() {
-        if (!Files.exists(GIT_PATH)) {
-            throw new IllegalStateException("It seems that it's not a git repository. " +
-                    "Plugin goals should be executed from the root of the project.");
-        }
-
         if (!Files.exists(GIT_HOOKS_PATH)) {
             try {
                 Files.createDirectories(GIT_HOOKS_PATH);

--- a/src/main/java/io/github/pepperkit/githooks/InitHooksMojo.java
+++ b/src/main/java/io/github/pepperkit/githooks/InitHooksMojo.java
@@ -43,6 +43,12 @@ public class InitHooksMojo extends AbstractMojo {
 
     @Override
     public void execute() throws MojoExecutionException {
+        if (!gitHooksManager.isGitRepository()) {
+            getLog().info("No git repository found. " +
+                    "Plugin goals will only be executed from the root of the project.");
+            return;
+        }
+
         List<File> existingHookFiles = gitHooksManager.getExistingHookFiles();
         if (hooks == null) {
             existingHookFiles.forEach(File::delete);

--- a/src/test/java/io/github/pepperkit/githooks/InitHooksMojoTest.java
+++ b/src/test/java/io/github/pepperkit/githooks/InitHooksMojoTest.java
@@ -6,9 +6,7 @@
  */
 package io.github.pepperkit.githooks;
 
-import java.io.File;
 import java.io.IOException;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -32,6 +30,14 @@ class InitHooksMojoTest {
         gitHooksManagerMock = mock(GitHooksManager.class);
         initHooksMojo = new InitHooksMojo();
         initHooksMojo.gitHooksManager = gitHooksManagerMock;
+        when(gitHooksManagerMock.isGitRepository()).thenReturn(true);
+    }
+
+    @Test
+    void executesNothingIfNotAGitRepository() throws MojoExecutionException {
+        when(gitHooksManagerMock.isGitRepository()).thenReturn(false);
+        initHooksMojo.execute();
+        verify(gitHooksManagerMock, times(0)).getExistingHookFiles();
     }
 
     @Test


### PR DESCRIPTION
This is necessary when running maven from the working directory of submodule of a multi-maven module project which otherwise fails.